### PR TITLE
Allow URL to be provided as region

### DIFF
--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -19,11 +19,25 @@ func NewSquaredUpClient(region string, apiKey string) (*SquaredUpClient, error) 
 		return nil, err
 	}
 
-	return &SquaredUpClient{
+	req, err := http.NewRequest("GET", baseURL+"/api/plugins/latest", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %v", err)
+	}
+
+	client := &http.Client{}
+
+	squaredUpClient := &SquaredUpClient{
 		baseURL:    baseURL,
 		apiKey:     apiKey,
-		httpClient: &http.Client{},
-	}, nil
+		httpClient: client,
+	}
+
+	_, err = squaredUpClient.doRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("invalid api key with the provided region. check the api key and region and try again")
+	}
+
+	return squaredUpClient, nil
 }
 
 func determineBaseURL(region string) (string, error) {

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 type SquaredUpClient struct {
@@ -26,14 +27,14 @@ func NewSquaredUpClient(region string, apiKey string) (*SquaredUpClient, error) 
 }
 
 func determineBaseURL(region string) (string, error) {
-	switch region {
-	case "us":
+	if region == "us" {
 		return "https://api.squaredup.com", nil
-	case "eu":
+	} else if region == "eu" {
 		return "https://eu.api.squaredup.com", nil
-	default:
-		return "", fmt.Errorf("unsupported region: %s", region)
+	} else if strings.HasPrefix(region, "https://") {
+		return region, nil
 	}
+	return "", fmt.Errorf("unsupported region or URL scheme: %s", region)
 }
 
 func (c *SquaredUpClient) doRequest(req *http.Request) ([]byte, error) {

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -46,6 +46,7 @@ func determineBaseURL(region string) (string, error) {
 	} else if region == "eu" {
 		return "https://eu.api.squaredup.com", nil
 	} else if strings.HasPrefix(region, "https://") {
+		region = strings.TrimSuffix(region, "/")
 		return region, nil
 	}
 	return "", fmt.Errorf("unsupported region or URL scheme: %s", region)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"os"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -48,10 +49,7 @@ func (p *squaredupProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
 			"region": schema.StringAttribute{
 				Description: "Region of your SquaredUp instance. May also be set via the SQUAREDUP_REGION environment variable.",
 				Optional:    true,
-				Validators: []validator.String{stringvalidator.OneOf(
-					"us",
-					"eu",
-				)},
+				Validators:  []validator.String{stringvalidator.RegexMatches(regexp.MustCompile(`^(us|eu|https://.*)$`), "Invalid region format. It must be either 'us', 'eu', or start with 'https://'")},
 			},
 			"api_key": schema.StringAttribute{
 				Description: "API Key for SquaredUp API. May also be set via the SQUAREDUP_API_KEY environment variable.",
@@ -137,8 +135,8 @@ func (p *squaredupProvider) Configure(ctx context.Context, req provider.Configur
 		resp.Diagnostics.AddError(
 			"Unable to Create SquaredUp API Client",
 			"An unexpected error occurred while creating the SquaredUp API client. "+
-				"Please check the configuration and try again. If the error persists, please open an issue on GitHub. "+
-				err.Error(),
+				"Please check the configuration and try again. If the error persists, please open an issue on GitHub. \n"+
+				"Error: "+err.Error(),
 		)
 		return
 	}


### PR DESCRIPTION
# Description

- Allowing url as region will help us to connect with our other accounts as well as this will allow us to provide stage overrides as well
- Added a check that will validate if the api key is valid with the provided region.

# Checklist:
- [x] Added a label: `bug-fix`, `feature`, or `enhancement`
- [x] PR description written
