### PR TITLE
Remove OA Url from State

### DIFF
--- a/docs/resources/dashboard_share.md
+++ b/docs/resources/dashboard_share.md
@@ -76,7 +76,6 @@ resource "squaredup_dashboard_share" "sample_dashboard_share" {
 
 ### Read-Only
 
-- `dashboard_share_link` (String) Shareable link for the dashboard
 - `id` (String) The ID of the dashboard share
 - `last_updated` (String) The last time the Dashboard Share was updated
 

--- a/internal/provider/resource_dashboard_share.go
+++ b/internal/provider/resource_dashboard_share.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -35,7 +34,6 @@ type DashboardSharing struct {
 	WorkspaceID           types.String `tfsdk:"workspace_id"`
 	RequireAuthentication types.Bool   `tfsdk:"require_authentication"`
 	EnableLink            types.Bool   `tfsdk:"enabled"`
-	SharedDashboardLink   types.String `tfsdk:"dashboard_share_link"`
 	LastUpdated           types.String `tfsdk:"last_updated"`
 }
 
@@ -71,10 +69,6 @@ func (r *DashboardShareResource) Schema(_ context.Context, _ resource.SchemaRequ
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(true),
-			},
-			"dashboard_share_link": schema.StringAttribute{
-				Description: "Shareable link for the dashboard",
-				Computed:    true,
 			},
 			"last_updated": schema.StringAttribute{
 				Description: "The last time the Dashboard Share was updated",
@@ -134,7 +128,6 @@ func (r *DashboardShareResource) Create(ctx context.Context, req resource.Create
 		WorkspaceID:           types.StringValue(sharedDashboard.WorkspaceID),
 		RequireAuthentication: types.BoolValue(sharedDashboard.Properties.RequireAuthentication),
 		EnableLink:            types.BoolValue(sharedDashboard.Properties.Enabled),
-		SharedDashboardLink:   types.StringValue(generateSharedDashboardURL(sharedDashboard.ID)),
 		LastUpdated:           types.StringValue(time.Now().Format(time.RFC850)),
 	}
 
@@ -168,7 +161,6 @@ func (r *DashboardShareResource) Read(ctx context.Context, req resource.ReadRequ
 		WorkspaceID:           types.StringValue(sharedDashboard.WorkspaceID),
 		RequireAuthentication: types.BoolValue(sharedDashboard.Properties.RequireAuthentication),
 		EnableLink:            types.BoolValue(sharedDashboard.Properties.Enabled),
-		SharedDashboardLink:   types.StringValue(generateSharedDashboardURL(sharedDashboard.ID)),
 	}
 
 	diags = resp.State.Set(ctx, &state)
@@ -220,7 +212,6 @@ func (r *DashboardShareResource) Update(ctx context.Context, req resource.Update
 		WorkspaceID:           types.StringValue(sharedDashboard.WorkspaceID),
 		RequireAuthentication: types.BoolValue(sharedDashboard.Properties.RequireAuthentication),
 		EnableLink:            types.BoolValue(sharedDashboard.Properties.Enabled),
-		SharedDashboardLink:   types.StringValue(generateSharedDashboardURL(sharedDashboard.ID)),
 		LastUpdated:           types.StringValue(time.Now().Format(time.RFC850)),
 	}
 
@@ -252,8 +243,4 @@ func (r *DashboardShareResource) Delete(ctx context.Context, req resource.Delete
 
 func (r *DashboardShareResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
-}
-
-func generateSharedDashboardURL(id string) string {
-	return "https://app.squaredup.com/openaccess/" + strings.Split(id, "-")[1]
 }

--- a/internal/provider/resource_dashboard_share_test.go
+++ b/internal/provider/resource_dashboard_share_test.go
@@ -66,7 +66,6 @@ resource "squaredup_dashboard_share" "sample_dashboard_share" {
 					resource.TestCheckResourceAttr("squaredup_dashboard_share.sample_dashboard_share", "require_authentication", "true"),
 					resource.TestCheckResourceAttr("squaredup_dashboard_share.sample_dashboard_share", "enabled", "true"),
 					resource.TestCheckResourceAttrSet("squaredup_dashboard_share.sample_dashboard_share", "id"),
-					resource.TestCheckResourceAttrSet("squaredup_dashboard_share.sample_dashboard_share", "dashboard_share_link"),
 				),
 			},
 			// Import Test


### PR DESCRIPTION
# Description
- Removed shared link from state file as there is no output of this to the user and the dashboard share url generate does not correctly set the url

# Checklist:
- [x] Added a label: `bug-fix`, `feature`, or `enhancement`
- [x] PR description written
