### PR TITLE
Validate Dashboard JSON after Mustache Rendering

### DIFF
--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -107,16 +107,11 @@ resource "squaredup_dashboard" "sample_dashboard" {
           },
           "id": "{{perf_lambda_errors_id}}",
           "group": {
-            "by": [
-              "data.lambdaErrors.label",
-              "uniqueValues"
-            ],
+            "by": ["data.lambdaErrors.label", "uniqueValues"],
             "aggregate": [
               {
                 "type": "sum",
-                "names": [
-                  "data.lambdaErrors.value"
-                ]
+                "names": ["data.lambdaErrors.value"]
               }
             ]
           }
@@ -151,9 +146,7 @@ resource "squaredup_dashboard" "sample_dashboard" {
           "aggregation": "top",
           "column": "data.cost.value_sum",
           "condition": {
-            "columns": [
-              "data.cost.value_sum"
-            ],
+            "columns": ["data.cost.value_sum"],
             "logic": {
               "if": [
                 {
@@ -161,7 +154,7 @@ resource "squaredup_dashboard" "sample_dashboard" {
                     {
                       "var": "top"
                     },
-                    500
+                    {{ cost_threshold }}
                   ]
                 },
                 "error",
@@ -182,16 +175,11 @@ resource "squaredup_dashboard" "sample_dashboard" {
           "pluginConfigId": "{{sample_data_source_id}}",
           "id": "{{cost_data_stream}}",
           "group": {
-            "by": [
-              "data.cost.label",
-              "uniqueValues"
-            ],
+            "by": ["data.cost.label", "uniqueValues"],
             "aggregate": [
               {
                 "type": "sum",
-                "names": [
-                  "data.cost.value"
-                ]
+                "names": ["data.cost.value"]
               }
             ]
           }
@@ -202,14 +190,10 @@ resource "squaredup_dashboard" "sample_dashboard" {
         "scope": {
           "query": "g.V().has('id', within(ids_xAvxTqo9n9QCEeCHq2d1)).has(\"__configId\", \"{{sample_data_source_id}}\").or(__.has(\"sourceType\", within(\"sample-function\",\"sample-server\")))",
           "bindings": {
-            "ids_xAvxTqo9n9QCEeCHq2d1": [
-              "{{acommon_node_id}}"
-            ]
+            "ids_xAvxTqo9n9QCEeCHq2d1": ["{{acommon_node_id}}"]
           },
           "queryDetail": {
-            "ids": [
-              "{{acommon_node_id}}"
-            ]
+            "ids": ["{{acommon_node_id}}"]
           }
         }
       }
@@ -225,6 +209,7 @@ EOT
     perf_lambda_errors_id = local.perf_lambda_errors_data_stream.id
     cost_data_stream      = local.cost_data_stream.id
     acommon_node_id       = data.squaredup_nodes.acommon_node.node_properties[0].id
+    cost_threshold        = 500
   })
   workspace_id = squaredup_workspace.application_workspace.id
   display_name = "Sample Dashboard"

--- a/examples/resources/squaredup_dashboard/resource.tf
+++ b/examples/resources/squaredup_dashboard/resource.tf
@@ -92,16 +92,11 @@ resource "squaredup_dashboard" "sample_dashboard" {
           },
           "id": "{{perf_lambda_errors_id}}",
           "group": {
-            "by": [
-              "data.lambdaErrors.label",
-              "uniqueValues"
-            ],
+            "by": ["data.lambdaErrors.label", "uniqueValues"],
             "aggregate": [
               {
                 "type": "sum",
-                "names": [
-                  "data.lambdaErrors.value"
-                ]
+                "names": ["data.lambdaErrors.value"]
               }
             ]
           }
@@ -136,9 +131,7 @@ resource "squaredup_dashboard" "sample_dashboard" {
           "aggregation": "top",
           "column": "data.cost.value_sum",
           "condition": {
-            "columns": [
-              "data.cost.value_sum"
-            ],
+            "columns": ["data.cost.value_sum"],
             "logic": {
               "if": [
                 {
@@ -146,7 +139,7 @@ resource "squaredup_dashboard" "sample_dashboard" {
                     {
                       "var": "top"
                     },
-                    500
+                    {{ cost_threshold }}
                   ]
                 },
                 "error",
@@ -167,16 +160,11 @@ resource "squaredup_dashboard" "sample_dashboard" {
           "pluginConfigId": "{{sample_data_source_id}}",
           "id": "{{cost_data_stream}}",
           "group": {
-            "by": [
-              "data.cost.label",
-              "uniqueValues"
-            ],
+            "by": ["data.cost.label", "uniqueValues"],
             "aggregate": [
               {
                 "type": "sum",
-                "names": [
-                  "data.cost.value"
-                ]
+                "names": ["data.cost.value"]
               }
             ]
           }
@@ -187,14 +175,10 @@ resource "squaredup_dashboard" "sample_dashboard" {
         "scope": {
           "query": "g.V().has('id', within(ids_xAvxTqo9n9QCEeCHq2d1)).has(\"__configId\", \"{{sample_data_source_id}}\").or(__.has(\"sourceType\", within(\"sample-function\",\"sample-server\")))",
           "bindings": {
-            "ids_xAvxTqo9n9QCEeCHq2d1": [
-              "{{acommon_node_id}}"
-            ]
+            "ids_xAvxTqo9n9QCEeCHq2d1": ["{{acommon_node_id}}"]
           },
           "queryDetail": {
-            "ids": [
-              "{{acommon_node_id}}"
-            ]
+            "ids": ["{{acommon_node_id}}"]
           }
         }
       }
@@ -210,6 +194,7 @@ EOT
     perf_lambda_errors_id = local.perf_lambda_errors_data_stream.id
     cost_data_stream      = local.cost_data_stream.id
     acommon_node_id       = data.squaredup_nodes.acommon_node.node_properties[0].id
+    cost_threshold  = 500
   })
   workspace_id = squaredup_workspace.application_workspace.id
   display_name = "Sample Dashboard"

--- a/examples/resources/squaredup_dashboard/resource.tf
+++ b/examples/resources/squaredup_dashboard/resource.tf
@@ -194,7 +194,7 @@ EOT
     perf_lambda_errors_id = local.perf_lambda_errors_data_stream.id
     cost_data_stream      = local.cost_data_stream.id
     acommon_node_id       = data.squaredup_nodes.acommon_node.node_properties[0].id
-    cost_threshold  = 500
+    cost_threshold        = 500
   })
   workspace_id = squaredup_workspace.application_workspace.id
   display_name = "Sample Dashboard"

--- a/internal/provider/resource_dashboard.go
+++ b/internal/provider/resource_dashboard.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -35,7 +36,7 @@ type squaredupDashboard struct {
 	DashboardID       types.String         `tfsdk:"id"`
 	DisplayName       types.String         `tfsdk:"display_name"`
 	WorkspaceID       types.String         `tfsdk:"workspace_id"`
-	DashboardTemplate jsontypes.Normalized `tfsdk:"dashboard_template"`
+	DashboardTemplate types.String         `tfsdk:"dashboard_template"`
 	TemplateBindings  jsontypes.Normalized `tfsdk:"template_bindings"`
 	DashboardContent  jsontypes.Normalized `tfsdk:"dashboard_content"`
 	Timeframe         types.String         `tfsdk:"timeframe"`
@@ -70,7 +71,6 @@ func (r *DashboardResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 			"dashboard_template": schema.StringAttribute{
 				Description: "Dashboard template to use for the dashboard",
 				Required:    true,
-				CustomType:  jsontypes.NormalizedType{},
 			},
 			"template_bindings": schema.StringAttribute{
 				Description: "Template Bindings used for replacing mustache template in the dashboard template. Needs to be a JSON encoded string.",
@@ -156,6 +156,16 @@ func (r *DashboardResource) Create(ctx context.Context, req resource.CreateReque
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Unable to render template",
+				err.Error(),
+			)
+			return
+		}
+		// Check if the rendered template is valid JSON
+		var jsonData interface{}
+		err = json.Unmarshal([]byte(updatedTemplate), &jsonData)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Rendered template is not a valid JSON. Please check that the JSON is valid after rendering the template with the template bindings.",
 				err.Error(),
 			)
 			return
@@ -253,6 +263,16 @@ func (r *DashboardResource) Update(ctx context.Context, req resource.UpdateReque
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Unable to render template",
+				err.Error(),
+			)
+			return
+		}
+		// Check if the rendered template is valid JSON
+		var jsonData interface{}
+		err = json.Unmarshal([]byte(updatedTemplate), &jsonData)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Rendered template is not a valid JSON. Please check that the JSON is valid after rendering the template with the template bindings.",
 				err.Error(),
 			)
 			return


### PR DESCRIPTION
# Description
There are cases in the template where a complex type or non-string type such as a number needs to be replaced.  As JSON validation occurs before the Mustache items like the below threshold fail to be deployed.

![image](https://github.com/squaredup/terraform-provider-squaredup/assets/56109016/2fd7de6b-1c87-47e7-b001-801e4bd22a47)

Instead of expecting template to be a valid JSON it will now check after the mustache has been rendered

# Checklist:
- [x] Added a label: `bug-fix`, `feature`, or `enhancement`
- [x] PR description written
