### PR TITLE
Node Lookup Fix

### DIFF
--- a/internal/provider/client_node.go
+++ b/internal/provider/client_node.go
@@ -60,6 +60,8 @@ func (c *SquaredUpClient) GetNodes(dataSourceId string, nodeName string, allowNu
 		}
 
 		gremlinQueryResults = response.GremlinQueryResults
+		break
+
 	}
 
 	return gremlinQueryResults, nil

--- a/internal/provider/client_node.go
+++ b/internal/provider/client_node.go
@@ -15,12 +15,12 @@ func (c *SquaredUpClient) GetNodes(dataSourceId string, nodeName string, allowNu
 	var gremlinQueryResults []GremlinQueryResult
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		rb := map[string]interface{}{
-			"gremlinQuery": "g.V().has('__configId', '" + dataSourceId + "').has('name', '" + nodeName + "').hasNot('__canonicalType').order().valueMap(true)",
+			"gremlinQuery": "g.V().has('__configId', '" + dataSourceId + "').has('name', '" + nodeName + "').hasNot('__canonicalType').valueMap(true)",
 		}
 
 		if nodeName == "" {
 			rb = map[string]interface{}{
-				"gremlinQuery": "g.V().has('__configId', '" + dataSourceId + "').hasNot('__canonicalType').order().valueMap(true)",
+				"gremlinQuery": "g.V().has('__configId', '" + dataSourceId + "').hasNot('__canonicalType').valueMap(true)",
 			}
 		}
 


### PR DESCRIPTION
# Description

- Without the `break` the request was being made 10 times which is the `maxRetries`
- Removed `.order()` as it fails if there are more than one object, and they appear to be un compareable

# Checklist:
- [x] Added a label: `bug-fix`, `feature`, or `enhancement`
- [x] PR description written
