### PR TITLE
Allow Nodes Datasource to be Filtered by Source Id

### DIFF
--- a/docs/data-sources/nodes.md
+++ b/docs/data-sources/nodes.md
@@ -22,17 +22,16 @@ resource "squaredup_datasource" "sample_data_source" {
   data_source_name = data.squaredup_datasources.sample_data.plugins[0].display_name
 }
 
-data "squaredup_nodes" "acommon_node" {
+data "squaredup_nodes" "acommon_node_by_name" {
   depends_on     = [squaredup_datasource.sample_data_source]
   data_source_id = squaredup_datasource.sample_data_source.id
   node_name      = "account-common-lambda"
 }
 
-data "squaredup_nodes" "s3_node" {
+data "squaredup_nodes" "acommon_node_by_id" {
   depends_on     = [squaredup_datasource.sample_data_source]
   data_source_id = squaredup_datasource.sample_data_source.id
-  node_name      = "account-common-s3"
-  allow_no_data  = true
+  node_source_id = "sample-server-2"
 }
 ```
 
@@ -47,6 +46,7 @@ data "squaredup_nodes" "s3_node" {
 
 - `allow_no_data` (Boolean) If true, the data source will return an empty list if its unable to find the node.
 - `node_name` (String) Node Name
+- `node_source_id` (String) Node Source ID
 
 ### Read-Only
 
@@ -59,4 +59,6 @@ Read-Only:
 
 - `display_name` (String)
 - `id` (String)
+- `source_id` (String)
 - `source_name` (String)
+- `type` (String)

--- a/examples/data-sources/squaredup_nodes/data-source.tf
+++ b/examples/data-sources/squaredup_nodes/data-source.tf
@@ -7,15 +7,14 @@ resource "squaredup_datasource" "sample_data_source" {
   data_source_name = data.squaredup_datasources.sample_data.plugins[0].display_name
 }
 
-data "squaredup_nodes" "acommon_node" {
+data "squaredup_nodes" "acommon_node_by_name" {
   depends_on     = [squaredup_datasource.sample_data_source]
   data_source_id = squaredup_datasource.sample_data_source.id
   node_name      = "account-common-lambda"
 }
 
-data "squaredup_nodes" "s3_node" {
+data "squaredup_nodes" "acommon_node_by_id" {
   depends_on     = [squaredup_datasource.sample_data_source]
   data_source_id = squaredup_datasource.sample_data_source.id
-  node_name      = "account-common-s3"
-  allow_no_data  = true
+  node_source_id = "sample-server-2"
 }

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -72,6 +72,8 @@ type GremlinQueryResult struct {
 	ID          string   `json:"id"`
 	SourceName  []string `json:"sourceName"`
 	DisplayName []string `json:"name"`
+	SourceID    []string `json:"sourceId"`
+	Type        []string `json:"type"`
 }
 
 type DashboardShare struct {


### PR DESCRIPTION
# Description
- `nodes` could have same name therefore added ability to filter by `sourceId`.
- Datasource will now also return `type` and `sourceId`

# Checklist:
- [x] Added a label: `bug-fix`, `feature`, or `enhancement`
- [x] PR description written
