### PR TITLE
Update Query to New Graph Query Endpoint

### DIFF
--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -61,6 +61,10 @@ func (c *SquaredUpClient) doRequest(req *http.Request) ([]byte, error) {
 
 	req.Header.Add("User-Agent", fmt.Sprintf("SquaredUp-Terraform-Provider/%s", c.version))
 
+	if req.Body != nil {
+		req.Header.Add("Content-Type", "application/json")
+	}
+
 	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/internal/provider/client_node.go
+++ b/internal/provider/client_node.go
@@ -38,7 +38,7 @@ func (c *SquaredUpClient) GetNodes(dataSourceId string, nodeName string, nodeSou
 			return nil, err
 		}
 
-		req, err := http.NewRequest("POST", c.baseURL+"/api/query", strings.NewReader(string(reqBody)))
+		req, err := http.NewRequest("POST", c.baseURL+"/api/graph/query", strings.NewReader(string(reqBody)))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
# Description

`/query` has been deprecated and `/graph/query` is the updated endpoint

# Checklist:
- [x] Added a label: `bug-fix`, `feature`, or `enhancement`
- [x] PR description written
